### PR TITLE
BACKLOG-22587: Remove <html> and add DOCTYPE

### DIFF
--- a/src/javascript/react/init.js
+++ b/src/javascript/react/init.js
@@ -42,7 +42,8 @@ export default () => {
             const styles = ReactDOMServer.renderToStaticMarkup(styleRegistry.styles());
             const stylesResource = styles ? `<jahia:resource type="inline" key="styles${props.id}">${styles}</jahia:resource>` : '';
             if (currentResource.getContextConfiguration() === 'page') {
-                return `<html>${cleanedRenderedElement}${stylesResource}</html>`;
+                // Set the HTML5 doctype that can't be rendered in JSX
+                return `<!DOCTYPE html>${cleanedRenderedElement}${stylesResource}`;
             }
 
             return `${cleanedRenderedElement}${stylesResource}`;

--- a/tests/cypress/e2e/ui/navMenuTest.cy.ts
+++ b/tests/cypress/e2e/ui/navMenuTest.cy.ts
@@ -20,7 +20,7 @@ const menuUrl = (template, depth, lvl = 0, page = '', base = 'home') =>
     `/cms/render/default/en/sites/npmTestSite/home${page}.${template}.html?maxDepth=${depth}&baseline=${base}&startLevel=${lvl}`;
 
 const cleanHTMLTags = str => {
-    if (str.includes('<html>')) {
+    if (str.includes('<!DOCTYPE html>')) {
         return str.substring(str.indexOf('['), str.lastIndexOf(']') + 1);
     }
 

--- a/tests/jahia-module/.gitignore
+++ b/tests/jahia-module/.gitignore
@@ -127,7 +127,6 @@ out
 
 #Yarn
 .yarn/*
-!.yarn/cache
 !.yarn/patches
 !.yarn/plugins
 !.yarn/releases

--- a/tests/jahia-module/src/react/server/templates/EventDefault.jsx
+++ b/tests/jahia-module/src/react/server/templates/EventDefault.jsx
@@ -4,7 +4,7 @@ import {footer, header, login, navMenu} from "./pageComponents";
 
 export const EventDefault = () => {
     const {currentResource} = useServerContext();
-    return (<>
+    return (<html lang="en">
         <head>
             <AddResources type={'css'} resources={'styles.css'}/>
         </head>
@@ -36,7 +36,7 @@ export const EventDefault = () => {
             </div>
         </div>
         </body>
-    </>)
+    </html>)
 }
 
 EventDefault.jahiaComponent = defineJahiaComponent({

--- a/tests/jahia-module/src/react/server/templates/EventFull.jsx
+++ b/tests/jahia-module/src/react/server/templates/EventFull.jsx
@@ -4,7 +4,7 @@ import {footer, header, login, navMenu} from "./pageComponents";
 
 export const EventFull = () => {
     const {currentResource} = useServerContext();
-    return (<>
+    return (<html lang="en">
         <head>
             <AddResources type={'css'} resources={'styles.css'}/>
         </head>
@@ -36,7 +36,7 @@ export const EventFull = () => {
             </div>
         </div>
         </body>
-    </>)
+    </html>)
 }
 
 EventFull.jahiaComponent = defineJahiaComponent({

--- a/tests/jahia-module/src/react/server/templates/PageBoundComponent.jsx
+++ b/tests/jahia-module/src/react/server/templates/PageBoundComponent.jsx
@@ -3,7 +3,7 @@ import {AddResources, Area, defineJahiaComponent, Render} from '@jahia/js-server
 import {footer, header, login, navMenu} from "./pageComponents";
 
 export const PageBoundComponent = () => {
-    return (<>
+    return (<html lang="en">
         <head>
             <AddResources type={'css'} resources={'styles.css'}/>
         </head>
@@ -39,7 +39,7 @@ export const PageBoundComponent = () => {
             </div>
         </div>
         </body>
-    </>)
+    </html>)
 }
 
 PageBoundComponent.jahiaComponent = defineJahiaComponent({

--- a/tests/jahia-module/src/react/server/templates/PageEvent.jsx
+++ b/tests/jahia-module/src/react/server/templates/PageEvent.jsx
@@ -3,7 +3,7 @@ import {AddResources, Area, defineJahiaComponent, Render} from '@jahia/js-server
 import {calendar, facets, footer, header, login, navMenu} from "./pageComponents";
 
 export const PageEvent = () => {
-    return (<>
+    return (<html lang="en">
         <head>
             <AddResources type={'css'} resources={'styles.css'}/>
         </head>
@@ -36,7 +36,7 @@ export const PageEvent = () => {
             </div>
         </div>
         </body>
-    </>)
+    </html>)
 }
 
 PageEvent.jahiaComponent = defineJahiaComponent({

--- a/tests/jahia-module/src/react/server/templates/PageHome.jsx
+++ b/tests/jahia-module/src/react/server/templates/PageHome.jsx
@@ -4,7 +4,7 @@ import {footer, header, login, navMenu} from "./pageComponents";
 
 export const PageHome = () => {
   return (
-    <>
+    <html lang="en">
         <head>
             <AddResources type={'css'} resources={'styles.css'}/>
         </head>
@@ -33,7 +33,7 @@ export const PageHome = () => {
                 </div>
             </div>
         </body>
-    </>
+    </html>
   )
 }
 

--- a/tests/jahia-module/src/react/server/templates/PageSimple.jsx
+++ b/tests/jahia-module/src/react/server/templates/PageSimple.jsx
@@ -13,14 +13,14 @@ export const PageSimple = () => {
         '            });\n' +
         '        </script>';
 
-    return (<>
+    return (<html lang="en">
         <head>
             <AddResources type={'css'} resources={'styles.css'}/>
         </head>
         <body>
         <AddResources type={'inline'} key={'inline-script-test'} inlineResource={inlineScript}/>
         <AddResources type={'javascript'} resources={'body-script.js'} targetTag={'body'}/>
-        <AddResources type={'javascript'} resources={'head-script.js'} />
+        <AddResources type={'javascript'} resources={'head-script.js'}/>
         <div className="page">
             <div className="header">
                 <div className="headerContent">
@@ -48,7 +48,7 @@ export const PageSimple = () => {
             </div>
         </div>
         </body>
-    </>)
+    </html>)
 }
 
 PageSimple.jahiaComponent = defineJahiaComponent({

--- a/tests/jahia-module/src/react/server/views/testContentTemplate/TestContentTemplate.jsx
+++ b/tests/jahia-module/src/react/server/views/testContentTemplate/TestContentTemplate.jsx
@@ -4,7 +4,7 @@ import {footer, header, login, navMenu} from '../../templates/pageComponents';
 
 export const TestContentTemplate = () => {
     const {currentResource} = useServerContext();
-    return (<>
+    return (<html lang="en">
         <head>
             <AddResources type={'css'} resources={'styles.css'}/>
         </head>
@@ -36,7 +36,7 @@ export const TestContentTemplate = () => {
             </div>
         </div>
         </body>
-    </>)
+    </html>)
 }
 
 TestContentTemplate.jahiaComponent = defineJahiaComponent({


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22587

## Description

Let the developers manage the `<html>` root tag (and control the `lang` attribute for instance). Also specify the HTML5 doctype (`<!DOCTYPE html>`) to have a valid HTML generated code. See https://www.w3.org/QA/Tips/Doctype for details.

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->


## Documentation

The sample templates in https://github.com/Jahia/npm-create-module must be changed to insert the `<html>` (see https://github.com/Jahia/npm-create-module/pull/43) tag and the tutorial documentation https://academy.jahia.com/get-started-with-javascript/introduction has to be updated accordingly.
