### PR TITLE
BACKLOG-22972: Support snapshot for JS modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,13 @@
             <version>1.3</version>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/jahia/modules/npm/modules/engine/npmhandler/NpmProtocolConnection.java
+++ b/src/main/java/org/jahia/modules/npm/modules/engine/npmhandler/NpmProtocolConnection.java
@@ -177,6 +177,7 @@ public class NpmProtocolConnection extends URLConnection {
                 .replaceAll("[^a-zA-Z0-9\\-\\.\\s]", "_"));
         setIfPresent(properties, "author", instructions, "Bundle-Vendor");
         instructions.put("Bundle-Version", getBundleVersion(properties, jahiaProps));
+        instructions.put("Implementation-Version", getImplementationVersion(properties, jahiaProps));
         setIfPresent(properties, "license", instructions, "Bundle-License");
 
         // Next lets setup Jahia headers
@@ -196,8 +197,16 @@ public class NpmProtocolConnection extends URLConnection {
     }
 
     static String getBundleVersion(Map<String, Object> properties, Map<String, Object> jahiaProps) {
+        return getVersionWithSnapshotSuffix(properties, jahiaProps, ".SNAPSHOT");
+    }
+
+    static String getImplementationVersion(Map<String, Object> properties, Map<String, Object> jahiaProps) {
+        return getVersionWithSnapshotSuffix(properties, jahiaProps, "-SNAPSHOT");
+    }
+
+    private static String getVersionWithSnapshotSuffix(Map<String, Object> properties, Map<String, Object> jahiaProps, String snapshotSuffix) {
         Object snapshotModeObj = jahiaProps.getOrDefault("snapshot", false);
-        return properties.get("version") + (Boolean.parseBoolean(String.valueOf(snapshotModeObj)) ? ".SNAPSHOT" : "");
+        return properties.get("version") + (Boolean.parseBoolean(String.valueOf(snapshotModeObj)) ? snapshotSuffix : "");
     }
 
     private void setIfPresent(Map<String, Object> inputProperties, String propertyName, Properties instructions, String instructionName) {

--- a/src/main/java/org/jahia/modules/npm/modules/engine/npmhandler/NpmProtocolConnection.java
+++ b/src/main/java/org/jahia/modules/npm/modules/engine/npmhandler/NpmProtocolConnection.java
@@ -176,14 +176,14 @@ public class NpmProtocolConnection extends URLConnection {
                 .replace('/', '-')
                 .replaceAll("[^a-zA-Z0-9\\-\\.\\s]", "_"));
         setIfPresent(properties, "author", instructions, "Bundle-Vendor");
-        instructions.put("Bundle-Version", properties.get("version"));
+        instructions.put("Bundle-Version", getBundleVersion(properties, jahiaProps));
         setIfPresent(properties, "license", instructions, "Bundle-License");
 
         // Next lets setup Jahia headers
         instructions.put("Jahia-Depends", jahiaProps.getOrDefault("module-dependencies", "default"));
         setIfPresent(jahiaProps, "deploy-on-site", instructions, "Jahia-Deploy-On-Site");
         instructions.put("Jahia-GroupId", jahiaProps.getOrDefault("group-id", "org.jahia.npm"));
-        setIfPresent(jahiaProps,"module-signature", instructions, "Jahia-Module-Signature");
+        setIfPresent(jahiaProps, "module-signature", instructions, "Jahia-Module-Signature");
         setIfPresent(jahiaProps, "module-priority", instructions, "Jahia-Module-Priority");
         instructions.put("Jahia-Module-Type", jahiaProps.getOrDefault("module-type", "module"));
         setIfPresent(jahiaProps, "private-app-store", instructions, "Jahia-Private-App-Store");
@@ -195,7 +195,12 @@ public class NpmProtocolConnection extends URLConnection {
         return instructions;
     }
 
-    private void setIfPresent(Map<String, Object> inputProperties,String propertyName, Properties instructions, String instructionName) {
+    static String getBundleVersion(Map<String, Object> properties, Map<String, Object> jahiaProps) {
+        Object snapshotModeObj = jahiaProps.getOrDefault("snapshot", false);
+        return properties.get("version") + (Boolean.parseBoolean(String.valueOf(snapshotModeObj)) ? ".SNAPSHOT" : "");
+    }
+
+    private void setIfPresent(Map<String, Object> inputProperties, String propertyName, Properties instructions, String instructionName) {
         if (inputProperties.containsKey(propertyName)) {
             instructions.put(instructionName, inputProperties.get(propertyName));
         }

--- a/src/test/java/org/jahia/modules/npm/modules/engine/npmhandler/NpmProtocolConnectionTest.java
+++ b/src/test/java/org/jahia/modules/npm/modules/engine/npmhandler/NpmProtocolConnectionTest.java
@@ -37,6 +37,31 @@ public class NpmProtocolConnectionTest {
         assertEquals("The version should not be suffixed with SNAPSHOT", PACKAGE_VERSION, version);
     }
 
+
+    @Test
+    public void GIVEN_the_snapshot_mode_is_enabled_with_a_boolean_WHEN_getting_the_implementation_version_THEN_the_snapshot_suffix_is_present() {
+        String version = NpmProtocolConnection.getImplementationVersion(createPackageProperties(), createJahiaProps(true));
+        assertEquals("The version should be suffixed with SNAPSHOT", PACKAGE_VERSION + "-SNAPSHOT", version);
+    }
+
+    @Test
+    public void GIVEN_the_snapshot_mode_is_enabled_with_a_string_WHEN_getting_the_implementation_version_THEN_the_snapshot_suffix_is_present() {
+        String version = NpmProtocolConnection.getImplementationVersion(createPackageProperties(), createJahiaProps("TrUe"));
+        assertEquals("The version should be suffixed with SNAPSHOT", PACKAGE_VERSION + "-SNAPSHOT", version);
+    }
+
+    @Test
+    public void GIVEN_the_snapshot_mode_is_disabled_WHEN_getting_the_implementation_version_THEN_the_snapshot_suffix_is_absent() {
+        String version = NpmProtocolConnection.getImplementationVersion(createPackageProperties(), createJahiaProps(false));
+        assertEquals("The version should not be suffixed with SNAPSHOT", PACKAGE_VERSION, version);
+    }
+
+    @Test
+    public void GIVEN_the_snapshot_mode_is_not_set_WHEN_getting_the_implementation_version_THEN_the_snapshot_suffix_is_absent() {
+        String version = NpmProtocolConnection.getImplementationVersion(createPackageProperties(), new HashMap<>());
+        assertEquals("The version should not be suffixed with SNAPSHOT", PACKAGE_VERSION, version);
+    }
+
     private static Map<String, Object> createPackageProperties() {
         Map<String, Object> packageProps = new Hashtable<>();
         packageProps.put("version", NpmProtocolConnectionTest.PACKAGE_VERSION);

--- a/src/test/java/org/jahia/modules/npm/modules/engine/npmhandler/NpmProtocolConnectionTest.java
+++ b/src/test/java/org/jahia/modules/npm/modules/engine/npmhandler/NpmProtocolConnectionTest.java
@@ -1,0 +1,52 @@
+package org.jahia.modules.npm.modules.engine.npmhandler;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class NpmProtocolConnectionTest {
+
+
+    public static final String PACKAGE_VERSION = "1.2.3";
+
+    @Test
+    public void GIVEN_the_snapshot_mode_is_enabled_with_a_boolean_WHEN_getting_the_bundle_version_THEN_the_snapshot_suffix_is_present() {
+        String version = NpmProtocolConnection.getBundleVersion(createPackageProperties(), createJahiaProps(true));
+        assertEquals("The version should be suffixed with SNAPSHOT", PACKAGE_VERSION + ".SNAPSHOT", version);
+    }
+
+    @Test
+    public void GIVEN_the_snapshot_mode_is_enabled_with_a_string_WHEN_getting_the_bundle_version_THEN_the_snapshot_suffix_is_present() {
+        String version = NpmProtocolConnection.getBundleVersion(createPackageProperties(), createJahiaProps("TrUe"));
+        assertEquals("The version should be suffixed with SNAPSHOT", PACKAGE_VERSION + ".SNAPSHOT", version);
+    }
+
+    @Test
+    public void GIVEN_the_snapshot_mode_is_disabled_WHEN_getting_the_bundle_version_THEN_the_snapshot_suffix_is_absent() {
+        String version = NpmProtocolConnection.getBundleVersion(createPackageProperties(), createJahiaProps(false));
+        assertEquals("The version should not be suffixed with SNAPSHOT", PACKAGE_VERSION, version);
+    }
+
+    @Test
+    public void GIVEN_the_snapshot_mode_is_not_set_WHEN_getting_the_bundle_version_THEN_the_snapshot_suffix_is_absent() {
+        String version = NpmProtocolConnection.getBundleVersion(createPackageProperties(), new HashMap<>());
+        assertEquals("The version should not be suffixed with SNAPSHOT", PACKAGE_VERSION, version);
+    }
+
+    private static Map<String, Object> createPackageProperties() {
+        Map<String, Object> packageProps = new Hashtable<>();
+        packageProps.put("version", NpmProtocolConnectionTest.PACKAGE_VERSION);
+        return packageProps;
+    }
+
+    private static Map<String, Object> createJahiaProps(Object snapshotModeValue) {
+        HashMap<String, Object> jahiaProps = new HashMap<>();
+        jahiaProps.put("snapshot", snapshotModeValue);
+        return jahiaProps;
+    }
+}
+


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22972

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Support a new property `"snapshot"` in the `package.json` (of the `"jahia"` section) where developers can specify that the Javascript module  should be built and installed as a _SNAPSHOT_ version.
Usage:
```json5
{
  "name": "solid-template",
  "version": "1.2.3",
  "jahia": {
    "snapshot": true,
    ... // rest of the properties
  },
  ... // rest of the properties
} 
```

When such a package is being deployed, the NPM module engine considers it as a _SNAPSHOT_ OSGI bundle.

If the property is missing or set to an invalid, the feature is disabled.

Related to https://github.com/Jahia/javascript-components/pull/274.

## Tests

The following are included in this PR
- [x] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [x] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [x] Performance
- [x] Migration
- [x] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
