### PR TITLE
PIPELINE-76: Trigger pagerduty notifications when sonar scans are failing

### DIFF
--- a/.github/workflows/schedule-sonar.yml
+++ b/.github/workflows/schedule-sonar.yml
@@ -7,47 +7,16 @@ on:
   schedule:
     - cron: '0 4 * * 1,3,5' # At 4AM, on Monday, Wednesday and Friday
 
-env:
-  MODULE_ID: npm-modules-engine
-
 jobs:
   sonar-analysis:
-    name: Sonar Analysis
-    runs-on: self-hosted
-    env:
-      NEXUS_INTERNAL_URL: ${{ secrets.NEXUS_INTERNAL_URL }}
+    uses: Jahia/jahia-modules-workflows/sonar-scan/sonar-scan.yml@PIPELINE-76
+    secrets: inherit
+    # Keeping a matrix since 
     strategy:
       fail-fast: false
       matrix:
-         supported_branches: ["${{ github.event.repository.default_branch }}"]
-    container:
-      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_8.0.312-node
-      credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ matrix.supported_branches }}
-      - uses: actions/setup-java@v4
-        with:
-          distribution: 'zulu'
-          java-version: '11.0.19'
-      - uses: jahia/jahia-modules-action/build@v2
-        with:
-          module_id: ${{ env.MODULE_ID }}
-          tests_module_type: 'npm'
-          mvn_settings_filepath: '.github/maven.settings.xml'
-          nexus_username: ${{ secrets.NEXUS_USERNAME }}
-          nexus_password: ${{ secrets.NEXUS_PASSWORD }}
-      - uses: jahia/jahia-modules-action/sonar-analysis@v2
-        with:
-          primary_release_branch: ${{ matrix.supported_branches }}
-          build_artifacts: ''
-          github_pr_id: ${{github.event.number}}
-          sonar_url: ${{ secrets.SONAR_URL }}
-          sonar_token: ${{ secrets.SONAR_TOKEN }}
-          nvd_apikey: ${{ secrets.NVD_APIKEY }}
-          mvn_settings_filepath: '.github/maven.settings.xml'
-          nexus_username: ${{ secrets.NEXUS_USERNAME }}
-          nexus_password: ${{ secrets.NEXUS_PASSWORD }}
+         git_branch: ["${{ github.event.repository.default_branch }}"]    
+    with:
+      module_id: npm-modules-engine
+      tests_module_type: npm
+      git_branch: ${{ matrix.git_branch }}

--- a/.github/workflows/schedule-sonar.yml
+++ b/.github/workflows/schedule-sonar.yml
@@ -20,3 +20,4 @@ jobs:
       module_id: npm-modules-engine
       tests_module_type: npm
       git_branch: ${{ matrix.git_branch }}
+      incident_service: npm-modules-engine-sonar

--- a/.github/workflows/schedule-sonar.yml
+++ b/.github/workflows/schedule-sonar.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   sonar-analysis:
-    uses: Jahia/jahia-modules-workflows/sonar-scan/sonar-scan.yml@PIPELINE-76
+    uses: Jahia/jahia-modules-action/.github/workflows/sonar-scan/sonar-scan.yml@PIPELINE-76
     secrets: inherit
     # Keeping a matrix since 
     strategy:

--- a/.github/workflows/schedule-sonar.yml
+++ b/.github/workflows/schedule-sonar.yml
@@ -11,7 +11,7 @@ jobs:
   sonar-analysis:
     uses: Jahia/jahia-modules-action/.github/workflows/sonar-scan.yml@v2
     secrets: inherit
-    # Keeping a matrix since 
+    # Keeping a matrix as it becomes useful when a maintenance branch is present.
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/schedule-sonar.yml
+++ b/.github/workflows/schedule-sonar.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   sonar-analysis:
-    uses: Jahia/jahia-modules-action/.github/workflows/sonar-scan/sonar-scan.yml@PIPELINE-76
+    uses: Jahia/jahia-modules-action/.github/workflows/sonar-scan.yml@PIPELINE-76
     secrets: inherit
     # Keeping a matrix since 
     strategy:

--- a/.github/workflows/schedule-sonar.yml
+++ b/.github/workflows/schedule-sonar.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   sonar-analysis:
-    uses: Jahia/jahia-modules-action/.github/workflows/sonar-scan.yml@PIPELINE-76
+    uses: Jahia/jahia-modules-action/.github/workflows/sonar-scan.yml@v2
     secrets: inherit
     # Keeping a matrix since 
     strategy:


### PR DESCRIPTION
- Migrated to a re-usable workflow and enabled pagerduty notifications.

Before merging that PR, the workflow will be updated to @v2 (instead of @PIPELINE-76)

Successful workflow run: Workflow run: https://github.com/Jahia/npm-modules-engine/actions/runs/10989955419/job/30509179127