### PR TITLE
TECH-1978: Call cy.logout() when using cy.login()

### DIFF
--- a/tests/cypress/e2e/ui/boundComponentTest.cy.ts
+++ b/tests/cypress/e2e/ui/boundComponentTest.cy.ts
@@ -135,5 +135,6 @@ describe('Check on bound components', () => {
         publishAndWaitJobEnding('/sites/npmTestSite/home/testBoundComponent');
         cy.visit('/sites/npmTestSite/home/testBoundComponent.html', {failOnStatusCode: false});
         cy.get('[data-testid="boundComponent_path"]').should('contain', '/npmTestSite/home/testBoundComponent/events');
+        cy.logout();
     });
 });

--- a/tests/cypress/e2e/ui/navMenuTest.cy.ts
+++ b/tests/cypress/e2e/ui/navMenuTest.cy.ts
@@ -58,6 +58,7 @@ describe('navMenu helper test parameters', () => {
             expect(tree.filter(menu => menu.render === '<a href="https://www.jahia.com" >externalLink</a>')).to
                 .exist;
         });
+        cy.logout();
     });
 
     it(`${templateName}: should have the dedicated view (menuComponent) for pages`, () => {
@@ -66,6 +67,7 @@ describe('navMenu helper test parameters', () => {
             const tree = JSON.parse(cleanHTMLTags(resp.body));
             expect(tree.filter(menu => menu.render === '/sites/npmTestSite/home/pageA')).to.exist;
         });
+        cy.logout();
     });
 
     it(`${templateName}: should display the selected depth of items`, () => {
@@ -98,6 +100,7 @@ describe('navMenu helper test parameters', () => {
                 }
             });
         });
+        cy.logout();
     });
 
     it(`${templateName}: should display the menu at the selected level`, () => {
@@ -122,6 +125,7 @@ describe('navMenu helper test parameters', () => {
                 }
             });
         });
+        cy.logout();
     });
 
     it(`${templateName}: should display the selected basenode menu`, () => {
@@ -147,6 +151,7 @@ describe('navMenu helper test parameters', () => {
                 assert.fail(`a menu is not suppose to be displayed with render ${menu.render}`);
             });
         });
+        cy.logout();
     });
 
     it(`${templateName}: should set the inPath and selected values for a menu entry`, () => {
@@ -194,5 +199,6 @@ describe('navMenu helper test parameters', () => {
                 }
             });
         });
+        cy.logout();
     });
 });

--- a/tests/cypress/support/e2e.js
+++ b/tests/cypress/support/e2e.js
@@ -66,4 +66,5 @@ before('Create NPM test site', () => {
 after('Clean', () => {
     cy.visit('/start', {failOnStatusCode: false});
     deleteSite('npmTestSite');
+    cy.logout();
 });


### PR DESCRIPTION
This prevents reaching the max number of authenticated visitors on free license

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/TECH-1978

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
Some Cypress e2e tests call `cy.login()` without calling its matching `cy.logout()`.
The consequence is that the the number of authenticated visitors keep increasing when running the tests and the trial license limit is reached (25 users).
