### PR TITLE
fix recent failure due to content editor HTML selector rename for section: Metadata

### DIFF
--- a/tests/cypress/e2e/module/moduleSettingsTest.cy.ts
+++ b/tests/cypress/e2e/module/moduleSettingsTest.cy.ts
@@ -33,7 +33,7 @@ describe('Check that NPM module settings (UI extensions, rules, configs) are cor
         const jcontent = new JContentPageBuilder(JContent.visit('npmTestSite', 'en', 'pages/home/testModuleSettings'));
         jcontent.getModule('/sites/npmTestSite/home/testModuleSettings/pagecontent').get().scrollIntoView();
         jcontent.getModule('/sites/npmTestSite/home/testModuleSettings/pagecontent/testContentEditorExtension').doubleClick();
-        getComponentBySelector(Collapsible, '[data-sel-content-editor-fields-group="Metadata"]').shouldBeExpanded();
+        getComponentBySelector(Collapsible, '[data-sel-content-editor-fields-group="Classification and Metadata"]').shouldBeExpanded();
         cy.logout();
     });
 


### PR DESCRIPTION
Related to https://github.com/Jahia/jahia-private/pull/2179 (more specifically [this change](https://github.com/Jahia/jahia-private/pull/2179/files#diff-cf8a8f5c26eca3af1c40ce42715ccec68d53c44978001e5c0d8fbb6df28cb1a4R321))