### PR TITLE
BACKLOG-23051: Add Javadoc

### DIFF
--- a/src/main/java/org/jahia/modules/npm/modules/engine/js/server/JcrHelper.java
+++ b/src/main/java/org/jahia/modules/npm/modules/engine/js/server/JcrHelper.java
@@ -6,10 +6,26 @@ import org.jahia.services.usermanager.JahiaUserManagerService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Helper class to perform JCR operations.
+ */
 public class JcrHelper {
 
     private static final Logger logger = LoggerFactory.getLogger(JcrHelper.class);
 
+    /**
+     * Execute JCR operations on a JCR session authenticated using the guest user and the "live" workspace.
+     * This is intended for server-side use. Example:
+     * <pre>
+     *     import {server, useServerContext} from '@jahia/js-server-core';
+     *     ...
+     *     const {renderContext, currentResource} = useServerContext();
+     *     server.jcr.doExecuteAsGuest(session => performJcrOperations(session, renderContext, currentResource));
+     * </pre>
+     *
+     * @param callback the callback to execute using the JCR session
+     * @return the result of the callback
+     */
     public Object doExecuteAsGuest(JCRCallback<Object> callback) {
         JCRTemplate template = JCRTemplate.getInstance();
         Object result = null;


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-23051

## Description

Add missing Javadoc for the code added in https://github.com/Jahia/npm-modules-engine/pull/185.
This documentation is important as it is used to generate the declaration files in js-server-core (see https://github.com/Jahia/js-server-core/tree/main/types/generated/build/types).


## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [x] Inline documentation
- [ ] Internal Documentation (wiki)
- [x] User-facing Documentation
