### PR TITLE
BACKLOG-23295: Use URL builders from hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint:fix": "eslint --ext js,jsx,json --fix ."
   },
   "dependencies": {
-    "@jahia/js-server-core": "^0.0.15",
+    "@jahia/js-server-core": "^0.0.16",
     "fast-text-encoding": "^1.0.6",
     "i18next": "^23.10.1",
     "prop-types": "^15.8.1",

--- a/tests/cypress/e2e/ui/urlHelperTest.cy.ts
+++ b/tests/cypress/e2e/ui/urlHelperTest.cy.ts
@@ -405,7 +405,7 @@ describe('Test on url helper', () => {
                 dataTestId: 'fragment_link',
                 tag: 'a',
                 attribute: 'href',
-                expectedURL: '/cms/render/default/en/sites/npmTestSite/home/testUrl/pagecontent/test.html.ajax'
+                expectedURL: '/sites/npmTestSite/home/testUrl/pagecontent/test.html.ajax'
             },
             {
                 dataTestId: 'path_not_exists',

--- a/tests/cypress/e2e/ui/urlHelperTest.cy.ts
+++ b/tests/cypress/e2e/ui/urlHelperTest.cy.ts
@@ -140,6 +140,12 @@ describe('Test on url helper', () => {
                 expectedURL: '/cms/render/default/en/sites/npmTestSite/home/linkedPage.myAction.do'
             },
             {
+                dataTestId: 'fragment_link',
+                tag: 'a',
+                attribute: 'href',
+                expectedURL: '/cms/render/default/en/sites/npmTestSite/home/testUrl/pagecontent/test.html.ajax'
+            },
+            {
                 dataTestId: 'path_not_exists',
                 tag: 'a',
                 attribute: 'href',
@@ -221,6 +227,12 @@ describe('Test on url helper', () => {
                 tag: 'a',
                 attribute: 'href',
                 expectedURL: '/sites/npmTestSite/home/linkedPage.myAction.do'
+            },
+            {
+                dataTestId: 'fragment_link',
+                tag: 'a',
+                attribute: 'href',
+                expectedURL: '/sites/npmTestSite/home/testUrl/pagecontent/test.html.ajax'
             },
             {
                 dataTestId: 'path_not_exists',
@@ -311,6 +323,12 @@ describe('Test on url helper', () => {
                 expectedURL: '/cms/render/default/en/sites/npmTestSite/home/linkedPage.myAction.do'
             },
             {
+                dataTestId: 'fragment_link',
+                tag: 'a',
+                attribute: 'href',
+                expectedURL: '/cms/render/default/en/sites/npmTestSite/home/testUrl/pagecontent/test.html.ajax'
+            },
+            {
                 dataTestId: 'path_not_exists',
                 tag: 'a',
                 attribute: 'href',
@@ -382,6 +400,12 @@ describe('Test on url helper', () => {
                 tag: 'a',
                 attribute: 'href',
                 expectedURL: '/sites/npmTestSite/home/linkedPage.myAction.do'
+            },
+            {
+                dataTestId: 'fragment_link',
+                tag: 'a',
+                attribute: 'href',
+                expectedURL: '/cms/render/default/en/sites/npmTestSite/home/testUrl/pagecontent/test.html.ajax'
             },
             {
                 dataTestId: 'path_not_exists',

--- a/tests/jahia-module/src/react/server/views/testUrl/TestUrl.jsx
+++ b/tests/jahia-module/src/react/server/views/testUrl/TestUrl.jsx
@@ -3,7 +3,7 @@ import {buildUrl, defineJahiaComponent, server, useServerContext, useUrlBuilder}
 
 export const TestUrl = () => {
     const {currentResource, renderContext} = useServerContext();
-    const {buildStaticUrl} = useUrlBuilder();
+    const {buildNodeUrl, buildStaticUrl, buildHtmlFragmentUrl} = useUrlBuilder();
 
     const imageNodeRef = currentResource.getNode().hasProperty('image') ?
         currentResource.getNode().getProperty('image').getValue().getNode() :
@@ -25,7 +25,7 @@ export const TestUrl = () => {
 
             {imageNodeRef &&
                 <div data-testid="image_reference">
-                    <img height="150" src={buildUrl({path: imageNodeRef.getPath()}, renderContext, currentResource)} alt="image"/>
+                    <img height="150" src={buildNodeUrl({nodePath: imageNodeRef.getPath()})} alt="image"/>
                 </div>}
 
             <div data-testid="image_static_resource">
@@ -35,33 +35,37 @@ export const TestUrl = () => {
             {linkNodeRef &&
                 <>
                     <div data-testid="content_link">
-                        <a href={buildUrl({path: linkNodeRef.getPath()}, renderContext, currentResource)}>content link - current context</a>
+                        <a href={buildNodeUrl({nodePath: linkNodeRef.getPath()})}>content link - current context</a>
                     </div>
                     <div data-testid="content_link_mode_edit">
-                        <a href={buildUrl({path: linkNodeRef.getPath(), mode:'edit'}, renderContext, currentResource)}>content link - edit</a>
+                        <a href={buildNodeUrl({nodePath: linkNodeRef.getPath(), mode: 'edit'},)}>content link - edit</a>
                     </div>
                     <div data-testid="content_link_mode_preview">
-                        <a href={buildUrl({path: linkNodeRef.getPath(), mode:'preview'}, renderContext, currentResource)}>content link - preview</a>
+                        <a href={buildNodeUrl({nodePath: linkNodeRef.getPath(), mode: 'preview'})}>content link -
+                            preview</a>
                     </div>
                     <div data-testid="content_link_mode_live">
-                        <a href={buildUrl({path: linkNodeRef.getPath(), mode:'live'}, renderContext, currentResource)}>content link - live</a>
+                        <a href={buildNodeUrl({nodePath: linkNodeRef.getPath(), mode: 'live'})}>content link - live</a>
                     </div>
                     <div data-testid="content_link_language_fr">
-                        <a href={buildUrl({path: linkNodeRef.getPath(), language:'fr'}, renderContext, currentResource)}>content link - FR</a>
+                        <a href={buildNodeUrl({nodePath: linkNodeRef.getPath(), language: 'fr'})}>content link - FR</a>
                     </div>
                     <div data-testid="content_link_parameters">
-                        <a href={buildUrl({path: linkNodeRef.getPath(), parameters: {param1: 'value1', param2: 'value2'}}, renderContext, currentResource)}>content link - parameters</a>
+                        <a href={buildNodeUrl({
+                            nodePath: linkNodeRef.getPath(),
+                            parameters: {param1: 'value1', param2: 'value2'}
+                        })}>content link - parameters</a>
                     </div>
                     <div data-testid="action_url">
-                        <a href={buildUrl({path: linkNodeRef.getPath(), extension:'.myAction.do'}, renderContext, currentResource)}>action link</a>
+                        <a href={buildNodeUrl({nodePath: linkNodeRef.getPath(), extension: '.myAction.do'})}>action
+                            link</a>
                     </div>
                 </>}
-
-            <div data-testid="absolute_external_link">
-                <a href={buildUrl({value: 'https://www.google.com'}, renderContext, currentResource)}>External absolute link</a>
+            <div data-testid="fragment_link">
+                <a href={buildHtmlFragmentUrl({nodePath: '/sites/npmTestSite/home/testUrl/pagecontent/test'})}>fragment link</a>
             </div>
             <div data-testid="path_not_exists">
-                <a href={buildUrl({path: '/sites/mySiteNotExists/home'}, renderContext, currentResource)}>Using a path of node that does not exists</a>
+                <a href={buildNodeUrl({nodePath: '/sites/mySiteNotExists/home'})}>Using a path of node that does not exists</a>
             </div>
             <div data-testid="no_weakref">
                 <a href={buildUrl({path: null})}>No weakref</a>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1588,9 +1588,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jahia/js-server-core@npm:^0.0.15":
-  version: 0.0.15
-  resolution: "@jahia/js-server-core@npm:0.0.15"
+"@jahia/js-server-core@npm:^0.0.16":
+  version: 0.0.16
+  resolution: "@jahia/js-server-core@npm:0.0.16"
   dependencies:
     graphql: "npm:^16.0.1"
     graphql-tag: "npm:^2.12.6"
@@ -1598,7 +1598,7 @@ __metadata:
     prop-types: "npm:^15.8.1"
     react: "npm:^18.2.0"
     react-i18next: "npm:^14.1.0"
-  checksum: 10c0/fc023eefaf8a46df6f33ae0195a70dd4a385b8c761e73cdad50774106debaa38ee702ba476150b0b59426875acdaf2126ddfb9717a8e867a0d2c186bfe54e60f
+  checksum: 10c0/c45b3d8651483a8b007c593664756e8a91336bb38a65b260e549dcc09fbf82ff5aaae17e526300ce60f33a129d05f92ea00a67fc0e5b85acaa1ac29ee6257d0a
   languageName: node
   linkType: hard
 
@@ -4899,7 +4899,7 @@ __metadata:
     "@babel/preset-react": "npm:^7.22.15"
     "@cyclonedx/webpack-plugin": "npm:^3.11.0"
     "@jahia/eslint-config": "npm:^1.1.0"
-    "@jahia/js-server-core": "npm:^0.0.15"
+    "@jahia/js-server-core": "npm:^0.0.16"
     babel-loader: "npm:^8.2.3"
     eslint: "npm:^6.7.2"
     eslint-plugin-jest: "npm:^23.8.0"


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-23295

## Description


Use new helpers from `useUrlBuilder` hook:
- `buildNodeUrl` to build a URL for a given JCR node
- `buildHtmlFragmentUrl` to build a URL for a fragment (new test added)

Also, remove the generation of an external absolute link as it was not tested and more importantly, it does not make sense to use `buildUrl` in this case (developers should simply use basic HTML: `a href="https://www.google.com">`).

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [x] Integration Tests

