### PR TITLE
BACKLOG-23244: Get bundle id regardless of bundle context status

### DIFF
--- a/src/main/java/org/jahia/modules/npm/modules/engine/NpmModuleListener.java
+++ b/src/main/java/org/jahia/modules/npm/modules/engine/NpmModuleListener.java
@@ -17,10 +17,7 @@ package org.jahia.modules.npm.modules.engine;
 
 import org.jahia.modules.npm.modules.engine.jsengine.GraalVMEngine;
 import org.jahia.modules.npm.modules.engine.registrars.Registrar;
-import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.BundleEvent;
-import org.osgi.framework.BundleListener;
+import org.osgi.framework.*;
 import org.osgi.service.component.annotations.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -111,7 +108,7 @@ public class NpmModuleListener implements BundleListener {
     }
 
     public boolean isNPMModule(Bundle bundle) {
-        return bundle.getBundleId() != engine.getBundleContext().getBundle().getBundleId() &&
+        return bundle.getBundleId() != FrameworkUtil.getBundle(engine.getClass()).getBundleId() &&
                 bundle.getHeaders().get(BUNDLE_HEADER_NPM_INIT_SCRIPT) != null;
     }
 }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-23244

## Description

Instead of retrieving the bundle id via the bundle context, retrieve it from the component's class.
This prevents an `IllegalStateException` to be thrown if the bundle context is no longer valid.
