### PR TITLE
BACKLOG-23301: Fix mapping for Jahia-GroupId metadata

### DIFF
--- a/src/main/java/org/jahia/modules/npm/modules/engine/npmhandler/NpmProtocolConnection.java
+++ b/src/main/java/org/jahia/modules/npm/modules/engine/npmhandler/NpmProtocolConnection.java
@@ -202,7 +202,8 @@ public class NpmProtocolConnection extends URLConnection {
         // Next lets setup Jahia headers
         instructions.put("Jahia-Depends", jahiaProps.getOrDefault("module-dependencies", "default"));
         setIfPresent(jahiaProps, "deploy-on-site", instructions, "Jahia-Deploy-On-Site");
-        instructions.put("Jahia-GroupId", jahiaProps.getOrDefault("group-id", "org.jahia.npm"));
+        Map<String, Object> mavenProps = getMavenProps(jahiaProps);
+        instructions.put("Jahia-GroupId", mavenProps.getOrDefault("groupId", "org.jahia.npm"));
         setIfPresent(jahiaProps, "module-signature", instructions, "Jahia-Module-Signature");
         setIfPresent(jahiaProps, "module-priority", instructions, "Jahia-Module-Priority");
         instructions.put("Jahia-Module-Type", jahiaProps.getOrDefault("module-type", "module"));
@@ -213,6 +214,15 @@ public class NpmProtocolConnection extends URLConnection {
         instructions.put("Jahia-Static-Resources", StringUtils.defaultIfEmpty((String) jahiaProps.get("static-resources"), "/css,/icons,/images,/img,/javascript") + ",/static");
         instructions.put("-removeheaders", "Private-Package, Export-Package");
         return instructions;
+    }
+
+    private Map<String, Object> getMavenProps(Map<String, Object> jahiaProps) {
+        try {
+            return (Map<String, Object>) jahiaProps.getOrDefault("maven",Collections.emptyMap());
+        } catch (ClassCastException e) {
+            logger.warn("The 'maven' section is expected to be a map! The whole section will be ignored.");
+            return Collections.emptyMap();
+        }
     }
 
     static String getBundleVersion(Map<String, Object> properties, Map<String, Object> jahiaProps) {

--- a/tests/cypress/e2e/module/moduleTransformationTest.cy.ts
+++ b/tests/cypress/e2e/module/moduleTransformationTest.cy.ts
@@ -6,7 +6,7 @@ describe('Check that the NPM module has been transformed properly and has the pr
                     console.log(result);
                     expect(result).to.contain('Bundle-Category: jahia-npm-module');
                     expect(result).to.contain('Bundle-Description: Jahia NPM Test module');
-                    expect(result).to.contain('Jahia-GroupId: org.jahia.npm');
+                    expect(result).to.contain('Jahia-GroupId: org.example.modules.npm');
                     expect(result).to.contain('Bundle-License: MIT');
                     expect(result).to.contain('Bundle-Name: @jahia/npm-module-example (npm module)');
                     expect(result).to.contain('Bundle-SymbolicName: jahia-npm-module-example');

--- a/tests/jahia-module/package.json
+++ b/tests/jahia-module/package.json
@@ -14,7 +14,7 @@
   },
   "jahia": {
     "maven": {
-      "groupId": "org.jahia.modules.npm",
+      "groupId": "org.example.modules.npm",
       "distributionManagement": {
         "repository": {
           "id": "jahia-releases",


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-23301

## Description

Fix the logic to populate the header property `Jahia-GroupId` in the `MANIFEST` from the value defined in the `package.json`, to use the one defined in `.jahia.maven.groupId` (also used when releasing a JS module).


### Background

While looking into https://support.jahia.com/browse/SUPPORT-317, it appears the mapping was incorrect to populate the `Jahia-GroupId` metatdata.
The `package.json` defines the value:
```json
"jahia": {
  "maven": {
    "groupId": "..."
```
When the `NpmProtocolConnection` was expecting:
```json
"jahia": {
  "group-id": "..."
```

NB: This will change the `groupId` of our Javascript modules (Luxe, npm-solid-react-templateset-example, etc.) when **installing** the modules, the `groupId` for their **releases** won't change as the Github actions already use the `.jahia.maven` section.
## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [x] Integration Tests
