### PR TITLE
BACKLOG-23081: Build in production mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint:fix": "eslint --ext js,jsx,json --fix ."
   },
   "dependencies": {
-    "@jahia/js-server-core": "^0.0.16",
+    "@jahia/js-server-core": "^0.0.17",
     "fast-text-encoding": "^1.0.6",
     "i18next": "^23.10.1",
     "prop-types": "^15.8.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,17 @@
   "repository": "git@github.com:Jahia/npm-modules-engine.git",
   "license": "MIT",
   "scripts": {
-    "build": "webpack --mode=development && webpack --config webpack.client.js --mode=development",
+    "clean-server": "rm -rf src/main/resources/META-INF/js/",
+    "clean-client": "rm -rf src/main/resources/javascript/",
+    "clean": "run clean-server && run clean-client",
+    "build-server:development": "webpack --mode=development",
+    "build-server:production": "webpack --mode=production",
+    "build-server": "run build-server:production",
+    "build-client:development": "webpack --config webpack.client.js --mode=development",
+    "build-client:production": "webpack --config webpack.client.js --mode=production",
+    "build-client": "run build-client:production",
+    "build": "run build-server && run build-client",
+    "build:development": "run build-server:development && run build-client:development",
     "lint": "eslint --ext js,jsx,json .",
     "lint:fix": "eslint --ext js,jsx,json --fix ."
   },

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,8 @@
             org.jahia.modules.graphql.provider.dxm.osgi.annotations;version="[2.7,4)",
             org.jahia.modules.graphql.provider.dxm.util;version="[2.7,4)",
         </import-package>
+        <frontend-maven-plugin.nodeVersion>v18.12.0</frontend-maven-plugin.nodeVersion>
+        <frontend-maven-plugin.yarnVersion>v1.22.19</frontend-maven-plugin.yarnVersion>
     </properties>
 
     <repositories>
@@ -191,14 +193,42 @@
                 </configuration>
                 <executions>
                     <execution>
+                        <id>npm install node and yarn pre-clean</id>
+                        <phase>pre-clean</phase>
+                        <goals>
+                            <goal>install-node-and-yarn</goal>
+                        </goals>
+                        <configuration>
+                            <nodeVersion>${frontend-maven-plugin.nodeVersion}</nodeVersion>
+                            <yarnVersion>${frontend-maven-plugin.yarnVersion}</yarnVersion>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>yarn install pre-clean</id>
+                        <phase>pre-clean</phase>
+                        <goals>
+                            <goal>yarn</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>yarn clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>yarn</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>clean</arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>npm install node and yarn</id>
                         <phase>generate-resources</phase>
                         <goals>
                             <goal>install-node-and-yarn</goal>
                         </goals>
                         <configuration>
-                            <nodeVersion>v18.12.0</nodeVersion>
-                            <yarnVersion>v1.22.19</yarnVersion>
+                            <nodeVersion>${frontend-maven-plugin.nodeVersion}</nodeVersion>
+                            <yarnVersion>${frontend-maven-plugin.yarnVersion}</yarnVersion>
                         </configuration>
                     </execution>
                     <execution>

--- a/webpack.client.js
+++ b/webpack.client.js
@@ -11,7 +11,9 @@ const cycloneDxWebpackPluginOptions = {
 };
 
 module.exports = (env, argv) => {
-    let config = {
+    const isDevelopment = argv.mode === 'development';
+    const mode = isDevelopment ? 'development' : 'production';
+    return {
         entry: {
             reactAppShell: path.resolve(__dirname, 'src/client-javascript/main')
         },
@@ -61,9 +63,7 @@ module.exports = (env, argv) => {
             }),
             new CycloneDxWebpackPlugin(cycloneDxWebpackPluginOptions)
         ],
-        devtool: 'inline-source-map',
-        mode: 'development'
+        devtool: isDevelopment ? 'inline-source-map' : 'source-map',
+        mode: mode
     };
-
-    return config;
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,9 @@ const cycloneDxWebpackPluginOptions = {
 };
 
 module.exports = (env, argv) => {
-    let config = {
+    const isDevelopment = argv.mode === 'development';
+    const mode = isDevelopment ? 'development' : 'production';
+    return {
         entry: {
             main: path.resolve(__dirname, 'src/javascript/index')
         },
@@ -33,7 +35,7 @@ module.exports = (env, argv) => {
             rules: [
                 {
                     test: /\.js$/,
-                    include:[
+                    include: [
                         path.resolve(__dirname, "node_modules/create-frame"),
                         path.resolve(__dirname, "node_modules/handlebars-helpers")
                     ],
@@ -60,9 +62,7 @@ module.exports = (env, argv) => {
         plugins: [
             new CycloneDxWebpackPlugin(cycloneDxWebpackPluginOptions)
         ],
-        devtool: "inline-source-map",
-        mode: "development"
+        devtool: isDevelopment ? 'inline-source-map' : 'source-map',
+        mode: mode
     };
-
-    return config;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1588,9 +1588,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jahia/js-server-core@npm:^0.0.16":
-  version: 0.0.16
-  resolution: "@jahia/js-server-core@npm:0.0.16"
+"@jahia/js-server-core@npm:^0.0.17":
+  version: 0.0.17
+  resolution: "@jahia/js-server-core@npm:0.0.17"
   dependencies:
     graphql: "npm:^16.0.1"
     graphql-tag: "npm:^2.12.6"
@@ -1598,7 +1598,7 @@ __metadata:
     prop-types: "npm:^15.8.1"
     react: "npm:^18.2.0"
     react-i18next: "npm:^14.1.0"
-  checksum: 10c0/c45b3d8651483a8b007c593664756e8a91336bb38a65b260e549dcc09fbf82ff5aaae17e526300ce60f33a129d05f92ea00a67fc0e5b85acaa1ac29ee6257d0a
+  checksum: 10c0/150625f6fffe1128ebcc3bdd15b6ff56883fa6eb992b85aa04fddf5d444a2330858cefab02e32a98e5a97e4947b353364545b90c0fb105b5b6289c5d531d813b
   languageName: node
   linkType: hard
 
@@ -4899,7 +4899,7 @@ __metadata:
     "@babel/preset-react": "npm:^7.22.15"
     "@cyclonedx/webpack-plugin": "npm:^3.11.0"
     "@jahia/eslint-config": "npm:^1.1.0"
-    "@jahia/js-server-core": "npm:^0.0.16"
+    "@jahia/js-server-core": "npm:^0.0.17"
     babel-loader: "npm:^8.2.3"
     eslint: "npm:^6.7.2"
     eslint-plugin-jest: "npm:^23.8.0"


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-23081

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

- Build _NPM Modules Engine_ with the Webpack mode set to `"production"`.
- Add granularity for the scripts defined in `package.json` to be able to build only the client or the server side. Also, provide development versions of those scripts (by default, the production mode is used).
- Bind a `yarn clean` to the `mvn clean` phase

**⚠️ Dependencies on other PRs ⚠️**
While not coupled with https://github.com/Jahia/js-server-core/pull/54, we should first merge it and then release a new version of _js-server-core_, to be embedded in this PR.