### PR TITLE
BACKLOG-23345: Rename useQuery -> useGQLQuery

### DIFF
--- a/tests/jahia-module/package.json
+++ b/tests/jahia-module/package.json
@@ -61,7 +61,7 @@
     "minimist": "^1.2.6"
   },
   "dependencies": {
-    "@jahia/js-server-core": "^0.0.15",
+    "@jahia/js-server-core": "^0.0.17",
     "i18next": "^23.10.1",
     "react": "^18.2.0",
     "react-i18next": "^14.1.0"

--- a/tests/jahia-module/src/helpers/menu.js
+++ b/tests/jahia-module/src/helpers/menu.js
@@ -1,6 +1,4 @@
-import {buildUrl, useQuery} from '@jahia/js-server-core';
-import {print} from 'graphql';
-import gql from 'graphql-tag';
+import {buildUrl} from '@jahia/js-server-core';
 
 /**
  * @typedef {Object} NavigationItem
@@ -24,53 +22,3 @@ export const buildNode = (origNode, session, renderContext, currentResource) => 
     return navigationItem;
 };
 
-const getPageAncestors = (workspace, path, types) => {
-    const result = useQuery({
-        query: print(gql`
-            query ($workspace: Workspace!, $path: String!, $types: [String]!){
-                jcr(workspace: $workspace) {
-                    nodeByPath(path: $path) {
-                        ancestors(fieldFilter: {filters:[{fieldName:"isNodeType", value:"true"}]}) {
-                            path
-                            isNodeType(type: {types: $types})
-                        }
-                    }
-                }
-            }
-        `),
-        variables: {
-            workspace,
-            path,
-            types
-        }
-    });
-    // Currently no error handling is done, it will be implemented once handled by the framework
-    return result.data ? result.data.jcr.nodeByPath.ancestors : [];
-};
-
-/**
- * Get the base node for the navigation menu based on the various parameters
- * @param {string} baseline the baseline to use to get the base node. If not specified or if 'home', the site's home page will be used, if 'currentPage', the current page will be used
- * @param {import('org.jahia.services.render').RenderContext} renderContext the current rendering context
- * @param {string} workspace the workspace to use: 'default' for the edit workspace, 'live' for the live workspace
- * @returns {import('org.jahia.services.content').JCRNodeWrapper} the baseline node to use for the navigation menu
- */
-export const getBaseNode = (baseline, renderContext, workspace) => {
-    const mainResourceNode = renderContext.getMainResource().getNode();
-    const pageAncestors = getPageAncestors(workspace, mainResourceNode.getPath(), ['jnt:page']);
-    if (!baseline || baseline === 'home') {
-        return renderContext.getSite().getHome();
-    }
-
-    if (baseline === 'currentPage') {
-        if (renderContext.getMainResource().getNode().isNodeType('jnt:page')) {
-            return mainResourceNode;
-        }
-
-        if (pageAncestors.length > 0) {
-            return mainResourceNode.getSession().getNode(pageAncestors.slice(-1)[0].path);
-        }
-    }
-
-    return mainResourceNode;
-};

--- a/tests/jahia-module/src/hooks/useBaseNode.js
+++ b/tests/jahia-module/src/hooks/useBaseNode.js
@@ -1,0 +1,28 @@
+import {usePageAncestors} from './usePageAncestors';
+
+/**
+ * Get the base node for the navigation menu based on the various parameters
+ * @param {string} baseline the baseline to use to get the base node. If not specified or if 'home', the site's home page will be used, if 'currentPage', the current page will be used
+ * @param {import('org.jahia.services.render').RenderContext} renderContext the current rendering context
+ * @param {string} workspace the workspace to use: 'default' for the edit workspace, 'live' for the live workspace
+ * @returns {import('org.jahia.services.content').JCRNodeWrapper} the baseline node to use for the navigation menu
+ */
+export const useBaseNode = (baseline, renderContext, workspace) => {
+    const mainResourceNode = renderContext.getMainResource().getNode();
+    const pageAncestors = usePageAncestors(workspace, mainResourceNode.getPath(), ['jnt:page']);
+    if (!baseline || baseline === 'home') {
+        return renderContext.getSite().getHome();
+    }
+
+    if (baseline === 'currentPage') {
+        if (renderContext.getMainResource().getNode().isNodeType('jnt:page')) {
+            return mainResourceNode;
+        }
+
+        if (pageAncestors.length > 0) {
+            return mainResourceNode.getSession().getNode(pageAncestors.slice(-1)[0].path);
+        }
+    }
+
+    return mainResourceNode;
+};

--- a/tests/jahia-module/src/hooks/usePageAncestors.js
+++ b/tests/jahia-module/src/hooks/usePageAncestors.js
@@ -1,0 +1,27 @@
+import {useGQLQuery} from '@jahia/js-server-core';
+import {print} from 'graphql/index';
+import gql from 'graphql-tag';
+
+export const usePageAncestors = (workspace, path, types) => {
+    const result = useGQLQuery({
+        query: print(gql`
+            query ($workspace: Workspace!, $path: String!, $types: [String]!){
+                jcr(workspace: $workspace) {
+                    nodeByPath(path: $path) {
+                        ancestors(fieldFilter: {filters:[{fieldName:"isNodeType", value:"true"}]}) {
+                            path
+                            isNodeType(type: {types: $types})
+                        }
+                    }
+                }
+            }
+        `),
+        variables: {
+            workspace,
+            path,
+            types
+        }
+    });
+    // Currently no error handling is done, it will be implemented once handled by the framework
+    return result.data ? result.data.jcr.nodeByPath.ancestors : [];
+};

--- a/tests/jahia-module/src/react/server/views/hydratedNavMenu/HydratedNavMenu.jsx
+++ b/tests/jahia-module/src/react/server/views/hydratedNavMenu/HydratedNavMenu.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import {defineJahiaComponent, HydrateInBrowser, server, useServerContext} from '@jahia/js-server-core';
 import SampleHydratedMenu from "../../../../client/SampleHydratedMenu";
-import {buildNode, getBaseNode} from "../../../../helpers/menu";
+import {buildNode} from "../../../../helpers/menu";
+import {useBaseNode} from "../../../../hooks/useBaseNode";
 
 export const HydratedNavMenu = () => {
     const {renderContext, currentResource} = useServerContext();
     const base = currentResource.getNode().getPropertyAsString('j:baselineNode');
-    const baseNode = getBaseNode(base, renderContext, renderContext.isLiveMode() ? 'LIVE' : 'EDIT');
+    const baseNode = useBaseNode(base, renderContext, renderContext.isLiveMode() ? 'LIVE' : 'EDIT');
     const staticMenu = server.jcr.doExecuteAsGuest(session => buildNode(baseNode, session, renderContext, currentResource));
 
     return (

--- a/tests/jahia-module/src/react/server/views/testGQL/TestGQL.jsx
+++ b/tests/jahia-module/src/react/server/views/testGQL/TestGQL.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import {defineJahiaComponent, useQuery, useServerContext} from "@jahia/js-server-core";
+import {defineJahiaComponent, useGQLQuery, useServerContext} from "@jahia/js-server-core";
 
 export const TestGQL = () => {
     const {currentNode} = useServerContext();
-    const result = useQuery({
+    const result = useGQLQuery({
         query: "query ($path:String!) { jcr { nodeByPath(path:$path) { name, properties { name, value } } } }",
         variables: {path: currentNode.getPath()}
     });

--- a/tests/jahia-module/yarn.lock
+++ b/tests/jahia-module/yarn.lock
@@ -1622,9 +1622,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jahia/js-server-core@npm:^0.0.15":
-  version: 0.0.15
-  resolution: "@jahia/js-server-core@npm:0.0.15"
+"@jahia/js-server-core@npm:^0.0.17":
+  version: 0.0.17
+  resolution: "@jahia/js-server-core@npm:0.0.17"
   dependencies:
     graphql: "npm:^16.0.1"
     graphql-tag: "npm:^2.12.6"
@@ -1632,7 +1632,7 @@ __metadata:
     prop-types: "npm:^15.8.1"
     react: "npm:^18.2.0"
     react-i18next: "npm:^14.1.0"
-  checksum: 10/042625e285015b6897340a8ad1e50fdf339f4cbe99909617cb0cae95c38db95ab7232324bf03e1ff0230a3ebd8fe384058e024ea7abb9ca1c64051f24cdbf9f4
+  checksum: 10/92e3b1953595c5dd1c77304766ce08629e4a5f08031223b25795cb587d7c813931fa1e53865c3ed4ea24d9a901fff559e4465e764144f2ad1a877eb90dbcdb9e
   languageName: node
   linkType: hard
 
@@ -1646,7 +1646,7 @@ __metadata:
     "@babel/preset-react": "npm:^7.0.0"
     "@babel/preset-typescript": "npm:^7.21.5"
     "@jahia/eslint-config": "npm:^2.1.0"
-    "@jahia/js-server-core": "npm:^0.0.15"
+    "@jahia/js-server-core": "npm:^0.0.17"
     "@jahia/scripts": "npm:^1.3.3"
     babel-loader: "npm:^9.1.3"
     clean-webpack-plugin: "npm:^4.0.0"


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-23345

## Description

Bump js-server-core to v0.0.17.
Replace `useQuery` hook by `useGQLQuery`, coming from the `@jahia/js-server-core` package.
Also, to follow the [React _Rules of hooks_](https://react.dev/reference/rules/rules-of-hooks#only-call-hooks-from-react-functions), rename the functions using `useGQLQuery` to convert them to React hooks (they must start with _use_).

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
